### PR TITLE
5 ingestion allow one off import from nightscout js

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Feasibility study to see if Go-based nightscout would be useful.
  - [X] Support larger bulk-insert. Currently limited to 10802 entries without batch pg inserts
  - [ ] Ignore duplicate data (same reading, same 30s period -> make nightscoutjs import work)
  - [ ] Write completed "backup" files when passing into new month/year
+ - [X] Support single-shot import from remote nightscout
 
 ##  Next Steps
  - [ ] serve bundled front-end

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Feasibility study to see if Go-based nightscout would be useful.
   sgv before uploading new ones
 - nightscout will return the most-recent-before-current-time entry for the
   `current` apiv1 endpoint, not the max-time entry
+- the v1 api `entries` endpoint will add an implicit date filter
+  (of now - 4 days) if one is specified in the query.
+  (see `lib/server/query.js` `TWO_DAYS * 2`).
+  Use `find[date][$gte]=1` to bypass.
 
 
 ### Known-used Endpoints

--- a/adapters/entry_bucket_repository.go
+++ b/adapters/entry_bucket_repository.go
@@ -24,6 +24,8 @@ import (
 // current: time (8bytes) + oid string ( 24 + 16 header = 40 bytes) = 48 bytes
 // proposed: time (8 bytes) + oid counter (4 bytes) = 12 bytes
 // type enum(4) and trend (enum 10) should be uint8 or smaller.
+// Potential issue/weirdness: imported entries will have created_time based on
+// the original/imported oid, not when this system first saw them.
 type memEntry struct {
 	EventTime   time.Time
 	CreatedTime time.Time

--- a/adapters/nightscout_repository.go
+++ b/adapters/nightscout_repository.go
@@ -1,0 +1,30 @@
+package repository
+
+import (
+	"context"
+	"github.com/adamlounds/nightscout-go/models"
+	nightscoutstore "github.com/adamlounds/nightscout-go/stores/nightscout"
+	"net/url"
+)
+
+type NightscoutRepository struct{}
+
+type NightscoutConfig struct {
+	URL        *url.URL
+	Token      string
+	APISecret  string
+	secretHash string
+}
+
+func NewNightscoutRepository() *NightscoutRepository {
+	return &NightscoutRepository{}
+}
+
+func (b *NightscoutRepository) FetchAllEntries(ctx context.Context, nsCfg NightscoutConfig) ([]models.Entry, error) {
+	store := nightscoutstore.New(nightscoutstore.NightscoutConfig{
+		URL:       nsCfg.URL,
+		Token:     nsCfg.Token,
+		APISecret: nsCfg.APISecret,
+	})
+	return store.FetchAllEntries(ctx)
+}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -56,6 +56,7 @@ func run(ctx context.Context, cfg config.ServerConfig) {
 
 	authRepository := repository.NewBucketAuthRepository(cfg.APISecretHash, cfg.DefaultRole)
 	entryRepository := repository.NewBucketEntryRepository(bs)
+	nightscoutRepository := repository.NewNightscoutRepository()
 
 	err = entryRepository.Boot(ctx)
 	if err != nil {
@@ -65,7 +66,8 @@ func run(ctx context.Context, cfg config.ServerConfig) {
 	authService := &models.AuthService{AuthRepository: authRepository}
 
 	apiV1C := controllers.ApiV1{
-		EntryRepository: entryRepository,
+		EntryRepository:      entryRepository,
+		NightscoutRepository: nightscoutRepository,
 	}
 	apiV1mw := controllers.ApiV1AuthnMiddleware{
 		AuthService: authService,

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -78,8 +78,9 @@ func run(ctx context.Context, cfg config.ServerConfig) {
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(apiV1mw.SetAuthentication)
 		r.Use(middleware.URLFormat)
-		r.With(apiV1mw.Authz("api:entries:read")).Get("/entries", apiV1C.ListEntries)
 		r.With(apiV1mw.Authz("api:entries:create")).Post("/entries", apiV1C.CreateEntries)
+		r.With(apiV1mw.Authz("api:entries:create")).Post("/entries/import/nightscout", apiV1C.ImportNightscoutEntries)
+		r.With(apiV1mw.Authz("api:entries:read")).Get("/entries", apiV1C.ListEntries)
 		r.With(apiV1mw.Authz("api.entries.read")).Get("/entries/{oid:[a-f0-9]{24}}", apiV1C.EntryByOid)
 		r.With(apiV1mw.Authz("api.entries.read")).Get("/entries/current", apiV1C.LatestEntry)
 	})

--- a/controllers/api1.go
+++ b/controllers/api1.go
@@ -336,9 +336,20 @@ func (a ApiV1) ImportNightscoutEntries(w http.ResponseWriter, r *http.Request) {
 	store := nightscoutstore.New(nsCfg)
 
 	entries, err := store.FetchAllEntries(ctx)
-	fmt.Printf("received entries %v\n", entries)
+	if err != nil {
+		log.Info("cannot fetch entries from ns", slog.Any("err", err))
+		http.Error(w, "Cannot fetch entries from remote nightscout instance", http.StatusBadRequest)
+		return
+	}
+	log.Debug("fetched entries from remote nightscout instance",
+		slog.Int("numEntries", len(entries)),
+		slog.Time("latestEntry", entries[0].Time),
+		slog.Time("earliestEntry", entries[len(entries)-1].Time),
+	)
 
-	w.WriteHeader(http.StatusCreated)
+	// TODO: import/store
+
+	w.WriteHeader(http.StatusOK)
 }
 
 func (a ApiV1) renderEntryList(w http.ResponseWriter, r *http.Request, entries []models.Entry) {

--- a/stores/nightscout/nightscout.go
+++ b/stores/nightscout/nightscout.go
@@ -1,0 +1,87 @@
+package nightscoutstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/adamlounds/nightscout-go/models"
+	slogctx "github.com/veqryn/slog-context"
+	"log/slog"
+	"net/url"
+)
+
+type NightscoutConfig struct {
+	URL       *url.URL
+	Token     string
+	APISecret string
+}
+
+type NightscoutStore struct {
+	URL       *url.URL
+	Token     string
+	APISecret string
+}
+
+var ErrAccessDenied = errors.New("nsstore: permission denied")
+
+func (cfg NightscoutConfig) String() string {
+	return fmt.Sprintf("host=%s token=%s api_secret=%s", cfg.URL.String(), cfg.Token, cfg.APISecret)
+}
+
+func New(cfg NightscoutConfig) *NightscoutStore {
+	return &NightscoutStore{
+		URL:       cfg.URL,
+		Token:     cfg.Token,
+		APISecret: cfg.APISecret,
+	}
+}
+
+func (b *NightscoutStore) Ping(ctx context.Context) error {
+	return nil
+	//_, err := b.Nightscout.Exists(ctx, "ping")
+	//return err
+}
+
+func (b *NightscoutStore) FetchAllEntries(ctx context.Context) ([]models.Entry, error) {
+	return b.fetchBatchOfEntries(ctx, 100, models.Entry{})
+}
+
+// fetchEntryBatch fetches a batch of entries from a remote nightscout server
+// notes: these will come in reverse date order, which is annoying from a
+// "having to sort" perspective.
+// For now, we are doing the simplest thing - fetch all entries and import them at once.
+//
+// if/when we want to address memory usage, we can think about methods to
+// import in smaller batches. Maybe a two-pass approach - firstly determine how
+// far back the remote nightscout server stores data (note auto-purge in ns is
+// only 90 days), and keep track of the entries (or at least their timestamps)
+// at the desired batch boundaries.
+func (b *NightscoutStore) fetchBatchOfEntries(ctx context.Context, batchSize int, lastSeen models.Entry) ([]models.Entry, error) {
+	log := slogctx.FromCtx(ctx)
+	log.Debug("fetchEntryBatch called", slog.String("last Oid", lastSeen.Oid))
+
+	if lastSeen.Oid != "" {
+		return []models.Entry{}, nil
+	}
+
+	return []models.Entry{
+		{
+			Oid:     "faked1",
+			Type:    "sgv",
+			SgvMgdl: 100,
+		},
+		{
+			Oid:     "faked2",
+			Type:    "sgv",
+			SgvMgdl: 102,
+		},
+	}, nil
+}
+
+func (b *NightscoutStore) IsAccessDeniedErr(err error) bool {
+	return errors.Is(err, ErrAccessDenied)
+}
+
+func (b *NightscoutStore) IsObjNotFoundErr(err error) bool {
+	return errors.Is(err, models.ErrNotFound)
+}

--- a/stores/nightscout/nightscout.go
+++ b/stores/nightscout/nightscout.go
@@ -83,7 +83,9 @@ func (b *NightscoutStore) Ping(ctx context.Context) error {
 // instance, in reverse date order
 func (b *NightscoutStore) FetchAllEntries(ctx context.Context) ([]models.Entry, error) {
 	maxBatches := 100 // just in case something _weird_ happens, don't keep hammering remote server
-	batchSize := 5000 // it may just be me, but my ns instance won't send more than 5417 entries, either in tsv or json...
+	batchSize := 1000 // it may just be me, but my ns instance won't send more than 5417 entries, either in tsv or json...
+	// another ns instance capped itself at 1152 entries, 258KB. Maybe investigate js side?
+	// Hypothesis: it's time based
 
 	lastEntry := models.Entry{}
 	allEntries := []models.Entry{}
@@ -102,11 +104,6 @@ func (b *NightscoutStore) FetchAllEntries(ctx context.Context) ([]models.Entry, 
 	}
 	return allEntries, nil
 }
-
-// reverse
-//for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
-//entries[i], entries[j] = entries[j], entries[i]
-//}
 
 var rfc3339msLayout = "2006-01-02T15:04:05.000Z"
 

--- a/stores/nightscout/nightscout.go
+++ b/stores/nightscout/nightscout.go
@@ -2,24 +2,46 @@ package nightscoutstore
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/adamlounds/nightscout-go/models"
 	slogctx "github.com/veqryn/slog-context"
 	"log/slog"
+	"net"
+	"net/http"
 	"net/url"
+	"path"
+	"strconv"
+	"time"
 )
 
 type NightscoutConfig struct {
-	URL       *url.URL
-	Token     string
-	APISecret string
+	URL        *url.URL
+	Token      string
+	APISecret  string
+	secretHash string
 }
 
 type NightscoutStore struct {
-	URL       *url.URL
-	Token     string
-	APISecret string
+	URL        *url.URL
+	Token      string
+	SecretHash string
+}
+
+type nsEntry struct {
+	Oid        string `json:"_id"`        // mongo object id [0-9a-f]{24} eg "67261314d689f977f773bc19"
+	Type       string `json:"type"`       // "sgv"
+	Direction  string `json:"direction"`  // "Flat"
+	Device     string `json:"device"`     // "nightscout-librelink-up"
+	DateString string `json:"dateString"` // rfc3339 plus ms
+	SysTime    string `json:"sysTime"`    // same as dateString
+	Date       int64  `json:"date"`       // ms since epoch
+	Mills      int64  `json:"mills"`      // ms since epoch
+	UtcOffset  int64  `json:"utcOffset"`  // always 0
+	SgvMgdl    int    `json:"sgv"`        //
 }
 
 var ErrAccessDenied = errors.New("nsstore: permission denied")
@@ -28,11 +50,26 @@ func (cfg NightscoutConfig) String() string {
 	return fmt.Sprintf("host=%s token=%s api_secret=%s", cfg.URL.String(), cfg.Token, cfg.APISecret)
 }
 
+func (cfg NightscoutConfig) SecretHash() string {
+	if cfg.secretHash == "" {
+		return cfg.secretHash
+	}
+	if cfg.APISecret == "" {
+		return ""
+	}
+	h := sha1.New()
+	h.Write([]byte(cfg.APISecret))
+	cfg.secretHash = hex.EncodeToString(h.Sum(nil))
+	return cfg.secretHash
+
+}
+
 func New(cfg NightscoutConfig) *NightscoutStore {
+
 	return &NightscoutStore{
-		URL:       cfg.URL,
-		Token:     cfg.Token,
-		APISecret: cfg.APISecret,
+		URL:        cfg.URL,
+		Token:      cfg.Token,
+		SecretHash: cfg.SecretHash(),
 	}
 }
 
@@ -42,9 +79,36 @@ func (b *NightscoutStore) Ping(ctx context.Context) error {
 	//return err
 }
 
+// FetchAllEntries fetches all possible entries from the remote nightscout
+// instance, in reverse date order
 func (b *NightscoutStore) FetchAllEntries(ctx context.Context) ([]models.Entry, error) {
-	return b.fetchBatchOfEntries(ctx, 100, models.Entry{})
+	maxBatches := 100 // just in case something _weird_ happens, don't keep hammering remote server
+	batchSize := 5000 // it may just be me, but my ns instance won't send more than 5417 entries, either in tsv or json...
+
+	lastEntry := models.Entry{}
+	allEntries := []models.Entry{}
+	for i := 0; i < maxBatches; i++ {
+		batchOfEntries, err := b.fetchBatchOfEntries(ctx, batchSize, lastEntry)
+		if err != nil {
+			return nil, fmt.Errorf("cannot FetchAllEntries: %w", err)
+		}
+
+		allEntries = append(allEntries, batchOfEntries...)
+		if len(batchOfEntries) < batchSize {
+			return allEntries, nil
+		}
+
+		lastEntry = batchOfEntries[len(batchOfEntries)-1]
+	}
+	return allEntries, nil
 }
+
+// reverse
+//for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+//entries[i], entries[j] = entries[j], entries[i]
+//}
+
+var rfc3339msLayout = "2006-01-02T15:04:05.000Z"
 
 // fetchEntryBatch fetches a batch of entries from a remote nightscout server
 // notes: these will come in reverse date order, which is annoying from a
@@ -58,24 +122,85 @@ func (b *NightscoutStore) FetchAllEntries(ctx context.Context) ([]models.Entry, 
 // at the desired batch boundaries.
 func (b *NightscoutStore) fetchBatchOfEntries(ctx context.Context, batchSize int, lastSeen models.Entry) ([]models.Entry, error) {
 	log := slogctx.FromCtx(ctx)
-	log.Debug("fetchEntryBatch called", slog.String("last Oid", lastSeen.Oid))
+	log.Debug("fetchEntryBatch called", slog.Int("batchSize", batchSize), slog.String("lastSeenTime", lastSeen.Time.Format(rfc3339msLayout)))
 
-	if lastSeen.Oid != "" {
-		return []models.Entry{}, nil
+	u := *b.URL
+	u.Path = path.Join(u.Path, "api", "v1", "entries.json")
+	q := u.Query()
+	q.Set("count", strconv.Itoa(batchSize))
+	if b.Token != "" {
+		q.Set("token", b.Token)
+	}
+	if b.SecretHash != "" {
+		q.Set("secret", b.SecretHash)
 	}
 
-	return []models.Entry{
-		{
-			Oid:     "faked1",
-			Type:    "sgv",
-			SgvMgdl: 100,
-		},
-		{
-			Oid:     "faked2",
-			Type:    "sgv",
-			SgvMgdl: 102,
-		},
-	}, nil
+	if lastSeen.Oid != "" {
+		// nb using `lt` in the absence of deduping. Once dedupe sorted, we
+		// should use `lte` instead.
+		// As the code currently stands, we will lose entries that occur in the
+		// same millisecond and happen to be on the batch boundary
+		q.Set("find[date][$lt]", strconv.FormatInt(lastSeen.Time.UnixMilli(), 10))
+	}
+
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req.Header.Add("User-Agent", "nightscout-go/0.3")
+	if b.SecretHash != "" {
+		req.Header.Add("api-secret", b.SecretHash)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("fetchBatchOfEntries cannot NewRequestWithContext: %w", err)
+	}
+
+	client := http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		var dnsError *net.DNSError
+		if errors.As(err, &dnsError) {
+			log.Info("fetchBatchOfEntries DNSError", slog.Any("err", dnsError))
+			return nil, fmt.Errorf("fetchBatchOfEntries remote server NOT FOUND: %w", err)
+		}
+		return nil, fmt.Errorf("fetchBatchOfEntries cannot Do req: %w", err)
+	}
+	if res.StatusCode != 200 {
+		log.Info("fetchBatchOfEntries got non-200 res", slog.Int("code", res.StatusCode), slog.String("url", u.String()))
+		return nil, fmt.Errorf("fetchBatchOfEntries got non-200 response: %w", err)
+	}
+
+	var nsEntries []nsEntry
+	err = json.NewDecoder(res.Body).Decode(&nsEntries)
+	if err != nil {
+		log.Info("fetchBatchOfEntries cannot parse entries", slog.Any("err", err))
+		return nil, err
+	}
+
+	mEntries := make([]models.Entry, len(nsEntries))
+	for i, e := range nsEntries {
+		entryTime := time.UnixMilli(int64(e.Date))
+		sysTime, err := time.Parse("2006-01-02T15:04:05.999Z", e.SysTime)
+		if err != nil {
+			sysTime = entryTime
+		}
+		mEntries[i] = models.Entry{
+			Oid:         e.Oid,
+			Type:        e.Type,
+			SgvMgdl:     e.SgvMgdl,
+			Direction:   e.Direction,
+			Device:      e.Device,
+			Time:        entryTime,
+			CreatedTime: sysTime,
+		}
+	}
+
+	log.Debug("fetchBatchOfEntries parsed entries",
+		slog.Int("batchSize", batchSize),
+		slog.Int("numEntriesParsed", len(mEntries)),
+		slog.Time("latestEntry", mEntries[0].Time),
+		slog.Time("earliestEntry", mEntries[len(mEntries)-1].Time),
+	)
+	return mEntries, nil
 }
 
 func (b *NightscoutStore) IsAccessDeniedErr(err error) bool {


### PR DESCRIPTION
Import from remote nightscout instance

Example trigger
```
curl -i -X POST -H "Content-Type: application/json" --data '{"url":"https://nightscout-js.recruitsuite.co.uk","token":"ns-remoteToken"}' 'http://localhost:3000/api/v1/entries/import/nightscout?token=local-token'
```

Importing 80k entries took a few seconds, including waiting for remote system