### PR TITLE
23 support webui login via api/v1/verifyauth

### DIFF
--- a/controllers/api1_auth_middleware.go
+++ b/controllers/api1_auth_middleware.go
@@ -40,7 +40,7 @@ func (a ApiV1AuthnMiddleware) Authz(requiredRole string) func(http.Handler) http
 			authn := middleware.GetAuthn(ctx)
 			log.Debug("Authzmw got authn from ctx", slog.Any("authn", authn), slog.String("requiredRole", requiredRole))
 
-			if a.IsPermitted(ctx, authn, requiredRole) {
+			if authn.IsPermitted(ctx, requiredRole) {
 				log.Debug("Authzmw ok", slog.String("requiredRole", requiredRole))
 				next.ServeHTTP(w, r)
 			} else {

--- a/models/auth.go
+++ b/models/auth.go
@@ -33,14 +33,16 @@ type Role struct {
 type AuthRepository interface {
 	GetAPISecretHash(ctx context.Context) string
 	GetDefaultRole(ctx context.Context) string
-	//FetchAllRoles(ctx middleware.Context) []*Role
-	FetchAuthSubjectByAuthToken(ctx context.Context, authToken string) *AuthSubject
+	FetchAllRoles(ctx context.Context) []*Role
+	FetchSubjectByToken(ctx context.Context, authToken string) *AuthSubject
+	FetchSubjectByHash(ctx context.Context, authHash string) *AuthSubject
 }
 
 type Authn struct {
 	AuthSubject   *AuthSubject
 	ApiSecretHash string
 	AuthToken     string
+	rolesByName   map[string]*Role
 }
 
 func (a Authn) LogValue() slog.Value {
@@ -55,11 +57,13 @@ func (a Authn) LogValue() slog.Value {
 
 func (service *AuthService) AuthFromHTTP(ctx context.Context, apiSecretHash string, authToken string) *Authn {
 	authSubject := service.FetchAuthSubject(ctx, apiSecretHash, authToken)
+	rolesByName := service.RolesByName(ctx)
 
 	return &Authn{
 		ApiSecretHash: apiSecretHash,
 		AuthToken:     authToken,
 		AuthSubject:   authSubject,
+		rolesByName:   rolesByName,
 	}
 }
 
@@ -72,10 +76,10 @@ func (service *AuthService) FetchAuthSubject(ctx context.Context, apiSecretHash 
 		return adminAuthSubject
 	}
 
-	as := service.FetchAuthSubjectByAuthToken(ctx, authToken)
+	as := service.FetchSubjectByToken(ctx, authToken)
 	if as.IsAnonymous() {
-		// api-secret header can contain a token 🤪
-		as = service.FetchAuthSubjectByAuthToken(ctx, apiSecretHash)
+		// api-secret header may contain a hashed token 🤪
+		as = service.FetchSubjectByHash(ctx, apiSecretHash)
 		if !as.IsAnonymous() {
 			log.Debug("api secret was an auth token", slog.String("name", as.Name))
 		}
@@ -97,16 +101,41 @@ var additionalRoles = map[string]*Role{
 	"cgm-uploader": {Name: "cgm-uploader", Permissions: []string{"api:entries:read", "api:entries:create"}},
 }
 
-func (service *AuthService) IsPermitted(ctx context.Context, a *Authn, requiredPermission string) bool {
+func (service *AuthService) FetchAllRoles(ctx context.Context) []*Role {
+	roles := make([]*Role, 0, len(defaultRoles)+len(additionalRoles))
+	for _, role := range defaultRoles {
+		roles = append(roles, role)
+	}
+	for _, role := range additionalRoles {
+		roles = append(roles, role)
+	}
+	return roles
+}
+
+func (service *AuthService) RolesByName(ctx context.Context) map[string]*Role {
+	allRoles := service.FetchAllRoles(ctx)
+	rolesByName := make(map[string]*Role, len(allRoles))
+	for _, role := range allRoles {
+		rolesByName[role.Name] = role
+	}
+	return rolesByName
+}
+
+func (service *AuthService) IsAPISecretHashValid(ctx context.Context, apiSecretHash string) (isValid bool) {
+	return apiSecretHash == service.AuthRepository.GetAPISecretHash(ctx)
+}
+
+func (as *AuthSubject) IsAnonymous() bool {
+	return as.Name == "anonymous"
+}
+
+func (a *Authn) IsPermitted(ctx context.Context, requiredPermission string) bool {
 	log := slogctx.FromCtx(ctx)
 	for _, roleName := range a.AuthSubject.RoleNames {
-		role, ok := defaultRoles[roleName]
+		role, ok := a.rolesByName[roleName]
 		if !ok {
-			role, ok = additionalRoles[roleName]
-			if !ok {
-				log.Debug("role not found", "roleName", roleName)
-				continue
-			}
+			log.Debug("role not found", "roleName", roleName)
+			continue
 		}
 
 		for _, permission := range role.Permissions {
@@ -135,12 +164,4 @@ func (service *AuthService) IsPermitted(ctx context.Context, a *Authn, requiredP
 	}
 
 	return false
-}
-
-func (service *AuthService) IsAPISecretHashValid(ctx context.Context, apiSecretHash string) (isValid bool) {
-	return apiSecretHash == service.AuthRepository.GetAPISecretHash(ctx)
-}
-
-func (as *AuthSubject) IsAnonymous() bool {
-	return as.Name == "anonymous"
 }


### PR DESCRIPTION
verified authn with api_secret and tokens. Some weirdness around nightscout's behaviour for admin - `rolefound` is returned as `NOTFOUND`, not entirely sure why but have made ns-go behave the same way.